### PR TITLE
Add category schema, migrations, API routes, and default category seeding

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,7 +9,8 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate"
+    "db:migrate": "drizzle-kit migrate",
+    "db:seed": "bun run src/db/seed.ts"
   },
   "dependencies": {
     "next": "15.3.0",

--- a/apps/server/src/app/api/categories/[id]/route.ts
+++ b/apps/server/src/app/api/categories/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { categories } from "@/db/schema/categories";
+import { eq, and } from "drizzle-orm";
+import { withAuth } from "@/lib/auth-middleware";
+
+async function deleteCategory(req: Request, context: { user: any }, { params }: { params: { id: string } }) {
+  try {
+    const category = await db
+      .select()
+      .from(categories)
+      .where(
+        and(
+          eq(categories.id, params.id),
+          eq(categories.userId, context.user.id)
+        )
+      )
+      .limit(1);
+
+    if (!category.length) {
+      return NextResponse.json(
+        { message: "Category not found or you don't have permission to delete it" },
+        { status: 404 }
+      );
+    }
+
+    // Check if it's a default category
+    if (category[0].isDefault) {
+      return NextResponse.json(
+        { message: "Cannot delete default categories" },
+        { status: 403 }
+      );
+    }
+
+    // Delete the category
+    await db
+      .delete(categories)
+      .where(
+        and(
+          eq(categories.id, params.id),
+          eq(categories.userId, context.user.id)
+        )
+      );
+
+    return NextResponse.json({
+      message: "Category deleted successfully"
+    });
+  } catch (error) {
+    console.error("[CATEGORY_DELETE] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export const DELETE = withAuth(deleteCategory);

--- a/apps/server/src/app/api/categories/route.ts
+++ b/apps/server/src/app/api/categories/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { categories } from "@/db/schema/categories";
+import { z } from "zod";
+import { eq, or } from "drizzle-orm";
+import { withAuth } from "@/lib/auth-middleware";
+
+const categorySchema = z.object({
+  name: z.string().min(1, "Category name is required"),
+  type: z.enum(["income", "expense"]),
+});
+
+async function createCategory(req: Request, context: { user: any }) {
+  try {
+    const body = await req.json();
+    const validatedData = categorySchema.parse(body);
+
+    const category = await db.insert(categories).values({
+      userId: context.user.id,
+      name: validatedData.name,
+      type: validatedData.type,
+      isDefault: false,
+    }).returning();
+
+    return NextResponse.json({
+      message: "Category created successfully",
+      data: category[0]
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Invalid request data", errors: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("[CATEGORIES_POST] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+async function getCategories(req: Request, context: { user: any }) {
+  try {
+    const userCategories = await db
+      .select()
+      .from(categories)
+      .where(
+        or(
+          eq(categories.userId, context.user.id),
+          eq(categories.isDefault, true)
+        )
+      );
+
+    return NextResponse.json({
+      message: "Categories retrieved successfully",
+      data: userCategories
+    });
+  } catch (error) {
+    console.error("[CATEGORIES_GET] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export const POST = withAuth(createCategory);
+export const GET = withAuth(getCategories);

--- a/apps/server/src/db/migrations/0002_furry_ben_urich.sql
+++ b/apps/server/src/db/migrations/0002_furry_ben_urich.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "categories" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text,
+	"name" text NOT NULL,
+	"type" text NOT NULL,
+	"is_default" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "categories" ADD CONSTRAINT "categories_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/server/src/db/migrations/meta/0002_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,477 @@
+{
+  "id": "be637d58-cdf6-44fb-9fae-be43758cf4d9",
+  "prevId": "894a17ed-f46e-435a-bd30-344d8554660d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_user_id_user_id_fk": {
+          "name": "categories_user_id_user_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_user_id_user_id_fk": {
+          "name": "transactions_user_id_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1749955654372,
       "tag": "0001_flawless_thena",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1749960309925,
+      "tag": "0002_furry_ben_urich",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/categories.ts
+++ b/apps/server/src/db/schema/categories.ts
@@ -1,0 +1,21 @@
+import { relations } from "drizzle-orm";
+import { pgTable, text, timestamp, uuid, boolean } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const categories = pgTable("categories", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  userId: text("user_id")
+    .references(() => user.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  type: text("type", { enum: ["income", "expense"] }).notNull(),
+  isDefault: boolean("is_default").default(false).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const categoriesRelations = relations(categories, ({ one }) => ({
+  user: one(user, {
+    fields: [categories.userId],
+    references: [user.id],
+  }),
+}));

--- a/apps/server/src/db/seed.ts
+++ b/apps/server/src/db/seed.ts
@@ -1,0 +1,91 @@
+import { db } from "@/db";
+import { categories } from "./schema/categories";
+import { eq } from "drizzle-orm";
+
+interface DefaultCategory {
+  name: string;
+  type: "income" | "expense";
+  isDefault: boolean;
+}
+
+const defaultCategories: DefaultCategory[] = [
+  // Expense Categories
+  { name: "Food & Dining", type: "expense", isDefault: true },
+  { name: "Transportation", type: "expense", isDefault: true },
+  { name: "Housing", type: "expense", isDefault: true },
+  { name: "Utilities", type: "expense", isDefault: true },
+  { name: "Entertainment", type: "expense", isDefault: true },
+  { name: "Healthcare", type: "expense", isDefault: true },
+  { name: "Miscellaneous", type: "expense", isDefault: true },
+
+  // Income Categories
+  { name: "Salary", type: "income", isDefault: true },
+  { name: "Freelance", type: "income", isDefault: true },
+  { name: "Investments", type: "income", isDefault: true },
+  { name: "Other Income", type: "income", isDefault: true },
+];
+
+export async function seedDefaultCategories() {
+  try {
+    const existingDefaults = await db
+      .select()
+      .from(categories)
+      .where(eq(categories.isDefault, true));
+
+    if (existingDefaults.length === 0) {
+      const now = new Date();
+      const categoriesWithTimestamps = defaultCategories.map((cat) => ({
+        ...cat,
+        createdAt: now,
+        updatedAt: now,
+      }));
+      
+      await db.insert(categories).values(categoriesWithTimestamps).returning();
+      return { success: true, message: "Default categories seeded successfully" };
+    }
+
+    // If categories exist, verify they match our default categories
+    const existingNames = new Set(existingDefaults.map(cat => cat.name));
+    const missingCategories = defaultCategories.filter(cat => !existingNames.has(cat.name));
+
+    if (missingCategories.length > 0) {
+      const now = new Date();
+      const categoriesWithTimestamps = missingCategories.map((cat) => ({
+        ...cat,
+        createdAt: now,
+        updatedAt: now,
+      }));
+      
+      await db.insert(categories).values(categoriesWithTimestamps).returning();
+      return { 
+        success: true, 
+        message: `Added ${missingCategories.length} missing default categories` 
+      };
+    }
+
+    return { 
+      success: true, 
+      message: "All default categories already exist" 
+    };
+  } catch (error) {
+    return { 
+      success: false, 
+      message: "Error seeding default categories", 
+      error 
+    };
+  }
+}
+
+// Execute the seeding function
+seedDefaultCategories()
+  .then((result) => {
+    if (!result.success) {
+      console.error(result.message, result.error);
+      process.exit(1);
+    }
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error("Seeding failed:", error);
+    process.exit(1);
+  }); 


### PR DESCRIPTION

This PR introduces the following enhancements to the server:

-   Added the `categories` database schema and corresponding migration files.
    
-   Implemented API routes for managing categories (CRUD operations).
    
-   Created a seeding script to insert default income and expense categories into the database.