### PR TITLE
Implement Budgeting and Saving Goals Features with Stats Endpoints

### DIFF
--- a/apps/server/src/app/api/budgets/[id]/route.ts
+++ b/apps/server/src/app/api/budgets/[id]/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { budgets } from "@/db/schema/budgets";
+import { z } from "zod";
+import { eq, and, ne } from "drizzle-orm";
+import { withAuth } from "@/lib/auth-middleware";
+
+const updateBudgetSchema = z.object({
+  amount: z.number().positive().optional(),
+  month: z.string().regex(/^\d{4}-\d{2}$/).optional(), // Format: YYYY-MM
+  year: z.string().regex(/^\d{4}$/).optional(), // Format: YYYY
+});
+
+
+async function updateBudget(req: Request, context: { user: any }, { params }: { params: { id: string } }) {
+  try {
+    const body = await req.json();
+    const validatedData = updateBudgetSchema.parse(body);
+
+    // Check if the budget exists and belongs to the user
+    const existingBudget = await db
+      .select()
+      .from(budgets)
+      .where(
+        and(
+          eq(budgets.id, params.id),
+          eq(budgets.userId, context.user.id)
+        )
+      )
+      .limit(1);
+
+    if (!existingBudget.length) {
+      return NextResponse.json(
+        { message: "Budget not found" },
+        { status: 404 }
+      );
+    }
+
+    if (validatedData.month || validatedData.year) {
+      const month = validatedData.month || existingBudget[0].month;
+      const year = validatedData.year || existingBudget[0].year;
+
+      const conflictingBudget = await db
+        .select()
+        .from(budgets)
+        .where(
+          and(
+            eq(budgets.userId, context.user.id),
+            eq(budgets.month, month),
+            eq(budgets.year, year),
+            ne(budgets.id, params.id)
+          )
+        )
+        .limit(1);
+
+      if (conflictingBudget.length > 0) {
+        return NextResponse.json(
+          { message: "Budget already exists for this month" },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Prepare update data with proper typing
+    const updateData: Partial<typeof budgets.$inferInsert> = {
+      updatedAt: new Date()
+    };
+
+    if (validatedData.amount !== undefined) {
+      updateData.amount = validatedData.amount.toFixed(2);
+    }
+    if (validatedData.month !== undefined) {
+      updateData.month = validatedData.month;
+    }
+    if (validatedData.year !== undefined) {
+      updateData.year = validatedData.year;
+    }
+
+    const updatedBudget = await db
+      .update(budgets)
+      .set(updateData)
+      .where(
+        and(
+          eq(budgets.id, params.id),
+          eq(budgets.userId, context.user.id)
+        )
+      )
+      .returning();
+
+    return NextResponse.json({
+      message: "Budget updated successfully",
+      data: updatedBudget[0]
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Invalid request data", errors: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("[BUDGET_PATCH] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export const PATCH = withAuth(updateBudget); 

--- a/apps/server/src/app/api/budgets/route.ts
+++ b/apps/server/src/app/api/budgets/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { budgets } from "@/db/schema/budgets";
+import { z } from "zod";
+import { eq, and } from "drizzle-orm";
+import { withAuth } from "@/lib/auth-middleware";
+
+const budgetSchema = z.object({
+  amount: z.number().positive(),
+  month: z.string().regex(/^\d{4}-\d{2}$/),
+  year: z.string().regex(/^\d{4}$/),
+});
+
+async function createBudget(req: Request, context: { user: any }) {
+  try {
+    const body = await req.json();
+    const validatedData = budgetSchema.parse(body);
+
+    // Check if budget already exists for this month
+    const existingBudget = await db
+      .select()
+      .from(budgets)
+      .where(
+        and(
+          eq(budgets.userId, context.user.id),
+          eq(budgets.month, validatedData.month),
+          eq(budgets.year, validatedData.year)
+        )
+      )
+      .limit(1);
+
+    if (existingBudget.length > 0) {
+      return NextResponse.json(
+        { message: "Budget already exists for this month" },
+        { status: 400 }
+      );
+    }
+
+    const budget = await db.insert(budgets).values({
+      userId: context.user.id,
+      amount: validatedData.amount.toFixed(2),
+      month: validatedData.month,
+      year: validatedData.year,
+    }).returning();
+
+    return NextResponse.json({
+      message: "Budget created successfully",
+      data: budget[0]
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Invalid request data", errors: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("[BUDGET_POST] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+async function getBudgets(req: Request, context: { user: any }) {
+  try {
+    const url = new URL(req.url);
+    const month = url.searchParams.get("month");
+    const year = url.searchParams.get("year");
+
+    const conditions = [eq(budgets.userId, context.user.id)];
+
+    if (month && year) {
+      conditions.push(eq(budgets.month, month));
+      conditions.push(eq(budgets.year, year));
+    }
+
+    const query = db
+      .select()
+      .from(budgets)
+      .where(and(...conditions));
+
+    const userBudgets = await query;
+
+    return NextResponse.json({
+      message: "Budgets retrieved successfully",
+      data: userBudgets
+    });
+  } catch (error) {
+    console.error("[BUDGETS_GET] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export const POST = withAuth(createBudget);
+export const GET = withAuth(getBudgets); 

--- a/apps/server/src/app/api/saving-goals/[id]/route.ts
+++ b/apps/server/src/app/api/saving-goals/[id]/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { savingGoals } from "@/db/schema/saving-goals";
+import { z } from "zod";
+import { eq, and } from "drizzle-orm";
+import { withAuth } from "@/lib/auth-middleware";
+
+const updateSavingGoalSchema = z.object({
+  name: z.string().min(1, "Name is required").optional(),
+  targetAmount: z.number().positive("Target amount must be positive").optional(),
+  currentAmount: z.number().min(0, "Current amount cannot be negative").optional(),
+  targetDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format (YYYY-MM-DD)").optional(),
+  isCompleted: z.boolean().optional(),
+});
+
+async function updateSavingGoal(req: Request, context: { user: any }, { params }: { params: { id: string } }) {
+  try {
+    const body = await req.json();
+    const validatedData = updateSavingGoalSchema.parse(body);
+
+    const existingGoal = await db
+      .select()
+      .from(savingGoals)
+      .where(
+        and(
+          eq(savingGoals.id, params.id),
+          eq(savingGoals.userId, context.user.id)
+        )
+      )
+      .limit(1);
+
+    if (!existingGoal.length) {
+      return NextResponse.json(
+        { message: "Saving goal not found" },
+        { status: 404 }
+      );
+    }
+
+    const updateData: Partial<typeof savingGoals.$inferInsert> = {
+      updatedAt: new Date()
+    };
+
+    if (validatedData.name !== undefined) {
+      updateData.name = validatedData.name;
+    }
+    if (validatedData.targetAmount !== undefined) {
+      updateData.targetAmount = validatedData.targetAmount.toFixed(2);
+    }
+    if (validatedData.currentAmount !== undefined) {
+      updateData.currentAmount = validatedData.currentAmount.toFixed(2);
+    }
+    if (validatedData.targetDate !== undefined) {
+      updateData.targetDate = new Date(validatedData.targetDate);
+    }
+    if (validatedData.isCompleted !== undefined) {
+      updateData.isCompleted = validatedData.isCompleted;
+    }
+
+    const updatedGoal = await db
+      .update(savingGoals)
+      .set(updateData)
+      .where(
+        and(
+          eq(savingGoals.id, params.id),
+          eq(savingGoals.userId, context.user.id)
+        )
+      )
+      .returning();
+
+    return NextResponse.json({
+      message: "Saving goal updated successfully",
+      data: updatedGoal[0]
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Invalid request data", errors: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("[SAVING_GOAL_PATCH] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+async function deleteSavingGoal(req: Request, context: { user: any }, { params }: { params: { id: string } }) {
+  try {
+    const existingGoal = await db
+      .select()
+      .from(savingGoals)
+      .where(
+        and(
+          eq(savingGoals.id, params.id),
+          eq(savingGoals.userId, context.user.id)
+        )
+      )
+      .limit(1);
+
+    if (!existingGoal.length) {
+      return NextResponse.json(
+        { message: "Saving goal not found" },
+        { status: 404 }
+      );
+    }
+
+    await db
+      .delete(savingGoals)
+      .where(
+        and(
+          eq(savingGoals.id, params.id),
+          eq(savingGoals.userId, context.user.id)
+        )
+      );
+
+    return NextResponse.json({
+      message: "Saving goal deleted successfully"
+    });
+  } catch (error) {
+    console.error("[SAVING_GOAL_DELETE] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export const PATCH = withAuth(updateSavingGoal);
+export const DELETE = withAuth(deleteSavingGoal); 

--- a/apps/server/src/app/api/saving-goals/route.ts
+++ b/apps/server/src/app/api/saving-goals/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { savingGoals } from "@/db/schema/saving-goals";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { withAuth } from "@/lib/auth-middleware";
+
+const savingGoalSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  targetAmount: z.number().positive("Target amount must be positive"),
+  currentAmount: z.number().min(0, "Current amount cannot be negative").optional(),
+  targetDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format (YYYY-MM-DD)"),
+});
+
+async function createSavingGoal(req: Request, context: { user: any }) {
+  try {
+    const body = await req.json();
+    const validatedData = savingGoalSchema.parse(body);
+
+    const goal = await db.insert(savingGoals).values({
+      userId: context.user.id,
+      name: validatedData.name,
+      targetAmount: validatedData.targetAmount.toFixed(2),
+      currentAmount: (validatedData.currentAmount || 0).toFixed(2),
+      targetDate: new Date(validatedData.targetDate),
+    }).returning();
+
+    return NextResponse.json({
+      message: "Saving goal created successfully",
+      data: goal[0]
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Invalid request data", errors: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("[SAVING_GOAL_POST] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+async function getSavingGoals(req: Request, context: { user: any }) {
+  try {
+    const goals = await db
+      .select()
+      .from(savingGoals)
+      .where(eq(savingGoals.userId, context.user.id))
+      .orderBy(savingGoals.createdAt);
+
+    return NextResponse.json({
+      message: "Saving goals retrieved successfully",
+      data: goals
+    });
+  } catch (error) {
+    console.error("[SAVING_GOALS_GET] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export const POST = withAuth(createSavingGoal);
+export const GET = withAuth(getSavingGoals); 

--- a/apps/server/src/app/api/stats/route.ts
+++ b/apps/server/src/app/api/stats/route.ts
@@ -1,0 +1,216 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { transactions } from "@/db/schema/transactions";
+import { categories } from "@/db/schema/categories";
+import { eq, and, gte, lte, sql } from "drizzle-orm";
+import { withAuth } from "@/lib/auth-middleware";
+import { z } from "zod";
+
+const dateRangeSchema = z.object({
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid start date format (YYYY-MM-DD)"),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid end date format (YYYY-MM-DD)"),
+});
+
+async function getOverview(req: Request, context: { user: any }) {
+  try {
+    const url = new URL(req.url);
+    const startDate = url.searchParams.get("startDate");
+    const endDate = url.searchParams.get("endDate");
+
+    if (!startDate || !endDate) {
+      return NextResponse.json(
+        { message: "Start date and end date are required" },
+        { status: 400 }
+      );
+    }
+
+    dateRangeSchema.parse({ startDate, endDate });
+
+    const conditions = [
+      eq(transactions.userId, context.user.id),
+      gte(transactions.date, new Date(startDate)),
+      lte(transactions.date, new Date(endDate))
+    ];
+
+    const [income, expenses] = await Promise.all([
+      db
+        .select({
+          total: sql<number>`COALESCE(SUM(CAST(${transactions.amount} AS DECIMAL)), 0)`,
+        })
+        .from(transactions)
+        .where(
+          and(
+            ...conditions,
+            eq(transactions.type, "income")
+          )
+        ),
+      db
+        .select({
+          total: sql<number>`COALESCE(SUM(CAST(${transactions.amount} AS DECIMAL)), 0)`,
+        })
+        .from(transactions)
+        .where(
+          and(
+            ...conditions,
+            eq(transactions.type, "expense")
+          )
+        ),
+    ]);
+
+    const netIncome = Number(income[0].total) - Number(expenses[0].total);
+
+    return NextResponse.json({
+      message: "Overview stats retrieved successfully",
+      data: {
+        income: Number(income[0].total),
+        expenses: Number(expenses[0].total),
+        netIncome,
+      }
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Invalid date range", errors: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("[STATS_OVERVIEW] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+async function getCategoryBreakdown(req: Request, context: { user: any }) {
+  try {
+    const url = new URL(req.url);
+    const startDate = url.searchParams.get("startDate");
+    const endDate = url.searchParams.get("endDate");
+
+    if (!startDate || !endDate) {
+      return NextResponse.json(
+        { message: "Start date and end date are required" },
+        { status: 400 }
+      );
+    }
+
+    dateRangeSchema.parse({ startDate, endDate });
+
+    const conditions = [
+      eq(transactions.userId, context.user.id),
+      gte(transactions.date, new Date(startDate)),
+      lte(transactions.date, new Date(endDate)),
+      eq(transactions.type, "expense")
+    ];
+
+    const categoryStats = await db
+      .select({
+        category: transactions.category,
+        total: sql<number>`COALESCE(SUM(CAST(${transactions.amount} AS DECIMAL)), 0)`,
+      })
+      .from(transactions)
+      .where(and(...conditions))
+      .groupBy(transactions.category);
+
+    return NextResponse.json({
+      message: "Category breakdown retrieved successfully",
+      data: categoryStats.map(stat => ({
+        category: stat.category,
+        total: Number(stat.total)
+      }))
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Invalid date range", errors: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("[STATS_CATEGORY] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+async function getMonthlyTrends(req: Request, context: { user: any }) {
+  try {
+    const url = new URL(req.url);
+    const startDate = url.searchParams.get("startDate");
+    const endDate = url.searchParams.get("endDate");
+
+    if (!startDate || !endDate) {
+      return NextResponse.json(
+        { message: "Start date and end date are required" },
+        { status: 400 }
+      );
+    }
+
+    dateRangeSchema.parse({ startDate, endDate });
+
+    const conditions = [
+      eq(transactions.userId, context.user.id),
+      gte(transactions.date, new Date(startDate)),
+      lte(transactions.date, new Date(endDate))
+    ];
+
+    const monthlyStats = await db
+      .select({
+        month: sql<string>`TO_CHAR(${transactions.date}, 'YYYY-MM')`,
+        type: transactions.type,
+        total: sql<number>`COALESCE(SUM(CAST(${transactions.amount} AS DECIMAL)), 0)`,
+      })
+      .from(transactions)
+      .where(and(...conditions))
+      .groupBy(sql`TO_CHAR(${transactions.date}, 'YYYY-MM')`, transactions.type)
+      .orderBy(sql`TO_CHAR(${transactions.date}, 'YYYY-MM')`);
+
+    // Transform the data
+    const monthlyData = monthlyStats.reduce((acc, stat) => {
+      const month = stat.month;
+      if (!acc[month]) {
+        acc[month] = { month, income: 0, expenses: 0 };
+      }
+      acc[month][stat.type === "income" ? "income" : "expenses"] = Number(stat.total);
+      return acc;
+    }, {} as Record<string, { month: string; income: number; expenses: number }>);
+
+    return NextResponse.json({
+      message: "Monthly trends retrieved successfully",
+      data: Object.values(monthlyData)
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Invalid date range", errors: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("[STATS_MONTHLY] Error:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export const GET = withAuth(async (req: Request, context: { user: any }) => {
+  const url = new URL(req.url);
+  const type = url.searchParams.get("type");
+
+  switch (type) {
+    case "overview":
+      return getOverview(req, context);
+    case "category":
+      return getCategoryBreakdown(req, context);
+    case "monthly":
+      return getMonthlyTrends(req, context);
+    default:
+      return NextResponse.json(
+        { message: "Invalid stats type. Use 'overview', 'category', or 'monthly'" },
+        { status: 400 }
+      );
+  }
+}); 

--- a/apps/server/src/db/migrations/0003_lyrical_champions.sql
+++ b/apps/server/src/db/migrations/0003_lyrical_champions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "budgets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"amount" numeric(10, 2) NOT NULL,
+	"month" text NOT NULL,
+	"year" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "budgets" ADD CONSTRAINT "budgets_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/server/src/db/migrations/0004_bright_ben_grimm.sql
+++ b/apps/server/src/db/migrations/0004_bright_ben_grimm.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "saving_goals" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"target_amount" numeric(10, 2) NOT NULL,
+	"current_amount" numeric(10, 2) DEFAULT '0' NOT NULL,
+	"target_date" timestamp NOT NULL,
+	"is_completed" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "saving_goals" ADD CONSTRAINT "saving_goals_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/server/src/db/migrations/meta/0003_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,549 @@
+{
+  "id": "717d7ed0-7843-4da7-a0c6-a0b8ad80d2be",
+  "prevId": "be637d58-cdf6-44fb-9fae-be43758cf4d9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_user_id_user_id_fk": {
+          "name": "budgets_user_id_user_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_user_id_user_id_fk": {
+          "name": "categories_user_id_user_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_user_id_user_id_fk": {
+          "name": "transactions_user_id_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/0004_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,635 @@
+{
+  "id": "d0608c5a-d81c-47aa-b91b-1e802089d0e8",
+  "prevId": "717d7ed0-7843-4da7-a0c6-a0b8ad80d2be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_user_id_user_id_fk": {
+          "name": "budgets_user_id_user_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_user_id_user_id_fk": {
+          "name": "categories_user_id_user_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saving_goals": {
+      "name": "saving_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_amount": {
+          "name": "target_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_amount": {
+          "name": "current_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saving_goals_user_id_user_id_fk": {
+          "name": "saving_goals_user_id_user_id_fk",
+          "tableFrom": "saving_goals",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_user_id_user_id_fk": {
+          "name": "transactions_user_id_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1749960309925,
       "tag": "0002_furry_ben_urich",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1749965470388,
+      "tag": "0003_lyrical_champions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1749965470388,
       "tag": "0003_lyrical_champions",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1749966357659,
+      "tag": "0004_bright_ben_grimm",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/budgets.ts
+++ b/apps/server/src/db/schema/budgets.ts
@@ -1,0 +1,22 @@
+import { relations } from "drizzle-orm";
+import { pgTable, text, timestamp, uuid, decimal } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const budgets = pgTable("budgets", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  amount: decimal("amount", { precision: 10, scale: 2 }).notNull(),
+  month: text("month").notNull(),
+  year: text("year").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const budgetsRelations = relations(budgets, ({ one }) => ({
+  user: one(user, {
+    fields: [budgets.userId],
+    references: [user.id],
+  }),
+})); 

--- a/apps/server/src/db/schema/saving-goals.ts
+++ b/apps/server/src/db/schema/saving-goals.ts
@@ -1,0 +1,24 @@
+ import { relations } from "drizzle-orm";
+import { pgTable, text, timestamp, uuid, decimal, boolean } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const savingGoals = pgTable("saving_goals", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  targetAmount: decimal("target_amount", { precision: 10, scale: 2 }).notNull(),
+  currentAmount: decimal("current_amount", { precision: 10, scale: 2 }).default("0").notNull(),
+  targetDate: timestamp("target_date").notNull(),
+  isCompleted: boolean("is_completed").default(false).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const savingGoalsRelations = relations(savingGoals, ({ one }) => ({
+  user: one(user, {
+    fields: [savingGoals.userId],
+    references: [user.id],
+  }),
+}));


### PR DESCRIPTION

This pull request introduces core features for managing budgets and saving goals, along with analytical stats endpoints:

-  Added budget schema and applied initial migration
    
-  Implemented budget API operations: get, create, and update
    
-  Introduced saving goals schema and migration
    
-  Implemented saving goals API operations
    
-  Added stats endpoints:
    
    -   `/api/stats/overview` for total income, expenses, and balance
        
    -   `/api/stats/expenses-by-category` for pie chart data
        
    -   `/api/stats/monthly-trends` for income vs expenses trends